### PR TITLE
Crashing on 1.21.4 launch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ hs_err_*.log
 replay_*.log
 *.hprof
 *.jfr
+/remappedSrc/com/mod/easyeat/EasyEat.java
+/remappedSrc/com/example/quickeatmod/mixin/ExampleMixin.java

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,14 +4,15 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.20.1
-yarn_mappings=1.20.1+build.10
-loader_version=0.15.11
+minecraft_version=1.21.1
+yarn_mappings=1.21.1+build.3
+loader_version=0.16.10
+
+# Fabric API
+fabric_version=0.115.0+1.21.1
+        
 
 # Mod Properties
-mod_version=1.0.0
+mod_version=1.0.1
 maven_group=com.mod.easyeat
 archives_base_name=EasyEat
-
-# Dependencies
-fabric_version=0.92.2+1.20.1

--- a/src/main/java/com/mod/easyeat/EasyEat.java
+++ b/src/main/java/com/mod/easyeat/EasyEat.java
@@ -3,6 +3,7 @@ package com.mod.easyeat;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.component.DataComponentTypes;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.Hand;
 
@@ -22,7 +23,7 @@ public class EasyEat implements ClientModInitializer {
             for (int i = 0; i < 9; i++) {
                 if (client.options.hotbarKeys[i].isPressed()) {
                     ItemStack stack = client.player.getInventory().getStack(i);
-                    if (stack.isFood()) {
+                    if (client.player.getMainHandStack().getItem().getComponents().contains(DataComponentTypes.FOOD)) {
                         if (!isQuickEating[i]) {
                             System.out.println("Starting to easy-eat food in slot " + (i+1));
                             client.player.getInventory().selectedSlot = i;
@@ -35,17 +36,14 @@ public class EasyEat implements ClientModInitializer {
                     if (isQuickEating[i]) {
                         System.out.println("Stopped easy-eating from slot " + (i+1));
                         isQuickEating[i] = false;
+                        client.options.useKey.setPressed(false);  // Reset use key when stopping
                     }
                 }
             }
 
-            // Only override use key if we're quick-eating
+            // Only set use key to pressed if we're actively quick-eating
             if (anyQuickEating) {
                 client.options.useKey.setPressed(true);
-            } else {
-                // Reset the use key to its actual state
-                boolean rightMousePressed = MinecraftClient.getInstance().mouse.wasRightButtonClicked();
-                client.options.useKey.setPressed(rightMousePressed);
             }
         });
     }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -24,7 +24,7 @@
 	],
 	"depends": {
 		"fabricloader": ">=0.15.11",
-		"minecraft": "~1.20.1",
+		"minecraft": "1.21.1 <=1.21.4",
 		"java": ">=17",
 		"fabric-api": "*"
 	},

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -24,7 +24,7 @@
 	],
 	"depends": {
 		"fabricloader": ">=0.15.11",
-		"minecraft": "1.21.1 <=1.21.4",
+		"minecraft": "~1.21",
 		"java": ">=17",
 		"fabric-api": "*"
 	},


### PR DESCRIPTION
Updated your version format to work with all versions of 1.21.x

Crash-dump of 1.0.1 under 1.21.4

```
[20:06:35] [main/INFO]: Loading Minecraft 1.21.4 with Fabric Loader 0.16.10
[20:06:35] [main/WARN]: Mod resolution failed
[20:06:35] [main/INFO]: Immediate reason: [HARD_DEP_INCOMPATIBLE_PRESELECTED easy_eat 1.0.1 {depends minecraft @ [1.21.1 <=1.21.4]}, ROOT_FORCELOAD_SINGLE easy_eat 1.0.1]
[20:06:35] [main/INFO]: Reason: [HARD_DEP easy_eat 1.0.1 {depends minecraft @ [1.21.1 <=1.21.4]}]
[20:06:35] [main/INFO]: Fix: add [], remove [], replace [[easy_eat 1.0.1] -> add:easy_eat 1 ([(-∞,∞)])]
[20:06:35] [main/ERROR]: Incompatible mods found!
net.fabricmc.loader.impl.FormattedException: Some of your mods are incompatible with the game or each other!
A potential solution has been determined, this may resolve your problem:
	 - Replace mod 'EasyEat' (easy_eat) 1.0.1 with any version that is compatible with:
		 - minecraft 1.21.4
More details:
	 - Mod 'EasyEat' (easy_eat) 1.0.1 requires version 1.21.1 of 'Minecraft' (minecraft), but only the wrong version is present: 1.21.4!
	at net.fabricmc.loader.impl.FormattedException.ofLocalized(FormattedException.java:51) ~[fabric-loader-0.16.10.jar:?]
	at net.fabricmc.loader.impl.FabricLoaderImpl.load(FabricLoaderImpl.java:196) ~[fabric-loader-0.16.10.jar:?]
	at net.fabricmc.loader.impl.launch.knot.Knot.init(Knot.java:146) ~[fabric-loader-0.16.10.jar:?]
	at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:68) [fabric-loader-0.16.10.jar:?]
	at net.fabricmc.loader.impl.launch.knot.KnotClient.main(KnotClient.java:23) [fabric-loader-0.16.10.jar:?]
```
